### PR TITLE
Rewrite CDN for both http and https URLs

### DIFF
--- a/cdn-enabler.php
+++ b/cdn-enabler.php
@@ -6,7 +6,7 @@ Description: Simply integrate a Content Delivery Network (CDN) into your WordPre
 Author: KeyCDN
 Author URI: https://www.keycdn.com
 License: GPLv2 or later
-Version: 1.0.4
+Version: 1.0.5
 */
 
 /*

--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -133,7 +133,7 @@ class CDN_Enabler
 	* run activation hook
 	*
 	* @since   0.0.1
-	* @change  1.0.3
+	* @change  1.0.5
 	*/
 
 	public static function handle_activation_hook() {
@@ -144,7 +144,8 @@ class CDN_Enabler
                 'dirs' => 'wp-content,wp-includes',
                 'excludes' => '.php',
                 'relative' => '1',
-                'https' => ''
+                'https' => '',
+                'both' => ''
             )
         );
 	}
@@ -194,7 +195,7 @@ class CDN_Enabler
 	* return plugin options
 	*
 	* @since   0.0.1
-	* @change  1.0.3
+	* @change  1.0.5
 	*
 	* @return  array  $diff  data pairs
 	*/
@@ -207,7 +208,8 @@ class CDN_Enabler
                 'dirs' => 'wp-content,wp-includes',
                 'excludes' => '.php',
                 'relative' => 1,
-                'https' => 0
+                'https' => 0,
+                'both' => 0
 			)
 		);
 	}
@@ -217,7 +219,7 @@ class CDN_Enabler
 	* run rewrite hook
 	*
 	* @since   0.0.1
-	* @change  1.0.3
+	* @change  1.0.5
 	*/
 
     public static function handle_rewrite_hook() {
@@ -236,7 +238,8 @@ class CDN_Enabler
     		$options['dirs'],
     		$excludes,
     		$options['relative'],
-    		$options['https']
+    		$options['https'],
+    		$options['both']
     	);
     	ob_start(
             array(&$rewriter, 'rewrite')

--- a/inc/cdn_enabler_settings.class.php
+++ b/inc/cdn_enabler_settings.class.php
@@ -48,13 +48,17 @@ class CDN_Enabler_Settings
         if (!isset($data['https'])) {
             $data['https'] = 0;
         }
+        if (!isset($data['both'])) {
+            $data['both'] = 0;
+        }
 
         return array(
             'url'        => esc_url($data['url']),
             'dirs'       => esc_attr($data['dirs']),
             'excludes'   => esc_attr($data['excludes']),
             'relative'   => (int)($data['relative']),
-            'https'      => (int)($data['https'])
+            'https'      => (int)($data['https']),
+            'both'      => (int)($data['both'])
         );
     }
 
@@ -85,7 +89,7 @@ class CDN_Enabler_Settings
     * settings page
     *
     * @since   0.0.1
-    * @change  1.0.3
+    * @change  1.0.5
     *
     * @return  void
     */
@@ -184,6 +188,20 @@ class CDN_Enabler_Settings
                                 <label for="cdn_enabler_https">
                                     <input type="checkbox" name="cdn_enabler[https]" id="cdn_enabler_https" value="1" <?php checked(1, $options['https']) ?> />
                                     <?php _e("Enable CDN for HTTPS connections (default: disabled).", "cdn-enabler"); ?>
+                                </label>
+                            </fieldset>
+                        </td>
+                    </tr>
+                    
+                    <tr valign="top">
+                        <th scope="row">
+                            <?php _e("CDN Both", "cdn-enabler"); ?>
+                        </th>
+                        <td>
+                            <fieldset>
+                                <label for="cdn_enabler_both">
+                                    <input type="checkbox" name="cdn_enabler[both]" id="cdn_enabler_both" value="1" <?php checked(1, $options['both']) ?> />
+                                    <?php _e("Enable CDN for both HTTP and HTTPS urls (default: disabled).", "cdn-enabler"); ?>
                                 </label>
                             </fieldset>
                         </td>

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,9 @@ The CDN Enabler plugin has been developed to link your content to the CDN URLs.
 
 == Changelog ==
 
+= 1.0.5 =
+* Rewrite CDN to both http and https URLs
+
 = 1.0.4 =
 * Removed unused code
 


### PR DESCRIPTION
Currently if you have your Wordpress blog url is http, the CDN enabler will not change https links and vice versa. This commit contains an additional setting and functionality that will overwrite both http and https links irrespective of the protocol specified in the blog url. If the setting is not enabled, previous functionality is preserved.