### PR TITLE
support for multiple cdn urls

### DIFF
--- a/inc/cdn_enabler_rewriter.class.php
+++ b/inc/cdn_enabler_rewriter.class.php
@@ -10,6 +10,7 @@ class CDN_Enabler_Rewriter
 {
     var $blog_url       = null;    // origin URL
     var $cdn_url        = null;    // CDN URL
+    var $cdn_count      = null;
 
     var $dirs           = null;    // included directories
     var $excludes       = []; // excludes
@@ -36,7 +37,8 @@ class CDN_Enabler_Rewriter
         $keycdn_zone_id
     ) {
         $this->blog_url       = $blog_url;
-        $this->cdn_url        = $cdn_url;
+        $this->cdn_url        = explode(PHP_EOL, $cdn_url);
+        $this->cdn_count      = count($this->cdn_url);
         $this->dirs           = $dirs;
         $this->excludes       = $excludes;
         $this->relative       = $relative;
@@ -117,16 +119,16 @@ class CDN_Enabler_Rewriter
 
         // is it a protocol independent URL?
         if (strpos($asset[0], '//') === 0) {
-            return str_replace($blog_url, $this->cdn_url, $asset[0]);
+            return str_replace($blog_url, $this->getRandomCDNUrl(), $asset[0]);
         }
 
         // check if not a relative path
         if (!$this->relative || strstr($asset[0], $blog_url)) {
-            return str_replace($subst_urls, $this->cdn_url, $asset[0]);
+            return str_replace($subst_urls, $this->getRandomCDNUrl(), $asset[0]);
         }
 
         // relative URL
-        return $this->cdn_url . $asset[0];
+        return $this->getRandomCDNUrl() . $asset[0];
     }
 
 
@@ -190,5 +192,36 @@ class CDN_Enabler_Rewriter
         $cdn_html = preg_replace_callback($regex_rule, [&$this, 'rewrite_url'], $html);
 
         return $cdn_html;
+    }
+
+
+    /**
+     * get a random cdn url from the list
+     *
+     * @since   1.0.6
+     * @change  1.0.6
+     *
+     * @return  string  random cdn url
+     */    
+
+    private function getRandomCDNUrl(){
+        return trim($this->cdn_url[$this->getRandomCDNIndex()]);
+    }
+
+
+    /**
+     * get a random cdn url index from the list
+     *
+     * @since   1.0.6
+     * @change  1.0.6
+     *
+     * @return  int  random cdn url index
+     */
+
+    private function getRandomCDNIndex(){
+        if($this->cdn_count == 1)
+            return 1;
+
+        return mt_rand(1, $this->cdn_count) - 1;
     }
 }

--- a/inc/cdn_enabler_settings.class.php
+++ b/inc/cdn_enabler_settings.class.php
@@ -56,7 +56,7 @@ class CDN_Enabler_Settings
         }
 
         return [
-            'url'             => esc_url($data['url']),
+            'url'             => esc_textarea($data['url']),
             'dirs'            => esc_attr($data['dirs']),
             'excludes'        => esc_attr($data['excludes']),
             'relative'        => (int)($data['relative']),
@@ -118,16 +118,18 @@ class CDN_Enabler_Settings
 
                    <tr valign="top">
                        <th scope="row">
-                           <?php _e("CDN URL", "cdn-enabler"); ?>
+                           <?php _e("CDN URLs", "cdn-enabler"); ?>
                        </th>
                        <td>
                            <fieldset>
                                <label for="cdn_enabler_url">
-                                   <input type="text" name="cdn_enabler[url]" id="cdn_enabler_url" value="<?php echo $options['url']; ?>" size="64" class="regular-text code" />
+                                   <textarea name="cdn_enabler[url]" id="cdn_enabler_url" class="regular-text code" rows="4"><?php echo $options['url']; ?></textarea>
                                </label>
 
                                <p class="description">
-                                   <?php _e("Enter the CDN URL without trailing", "cdn-enabler"); ?> <code>/</code>
+                                   <?php _e("Enter a CDN URL per line without trailing", "cdn-enabler"); ?> <code>/</code>
+                                   <br/>
+                                   <abbr title="<?php _e("Browsers limit the number of HTTP connections with the same domain name. This restriction is defined in the HTTP specification (RFC2616). Most modern browsers allow six connections per domain. Most older browsers allow only two connections per domain. You can have different CDN URLs pointing to the same server defined by CNAME records.", "cdn-enabler"); ?>"><?php _e("Why more than one CDN URL?", "cdn-enabler"); ?></abbr>
                                </p>
                            </fieldset>
                        </td>


### PR DESCRIPTION
support for multiple cdn urls to avoid browsers' max connections per server 


Browsers limit the number of HTTP connections with the same domain name. This restriction is defined in the HTTP specification (RFC2616). Most modern browsers allow six connections per domain. Most older browsers allow only two connections per domain. You can have different CDN URLs pointing to the same server defined by CNAME records.