### PR TITLE
Rewrite URLs by filtering the_content

### DIFF
--- a/cdn-enabler.php
+++ b/cdn-enabler.php
@@ -6,7 +6,7 @@
    Author: KeyCDN
    Author URI: https://www.keycdn.com
    License: GPLv2 or later
-   Version: 1.0.9
+   Version: 1.0.8
  */
 
 /*

--- a/cdn-enabler.php
+++ b/cdn-enabler.php
@@ -6,7 +6,7 @@
    Author: KeyCDN
    Author URI: https://www.keycdn.com
    License: GPLv2 or later
-   Version: 1.0.8
+   Version: 1.0.9
  */
 
 /*

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === CDN Enabler - WordPress CDN Plugin ===
-Contributors: keycdn, tmadeira
+Contributors: keycdn
 Tags: cdn, content delivery network, content distribution network
 Requires at least: 4.6
 Tested up to: 5.0

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === CDN Enabler - WordPress CDN Plugin ===
-Contributors: keycdn
+Contributors: keycdn, tmadeira
 Tags: cdn, content delivery network, content distribution network
 Requires at least: 4.6
 Tested up to: 5.0
@@ -46,6 +46,9 @@ The CDN Enabler plugin has been developed to link your content to the CDN URLs.
 
 
 == Changelog ==
+
+= 1.0.9 =
+* Rewrite URLs filtering the_content so that rendered HTML in REST API use CDN
 
 = 1.0.8 =
 * Purge CDN redirects to admin dashboard to avoid error messages


### PR DESCRIPTION
This is needed to rewrite URLs to use CDN in WP REST API endpoints.

As mentioned by @wtframework in https://wordpress.org/support/topic/rest-api-urls/, this plugin was not rewriting URLs in HTML rendered contents returned by WP REST API.

By using the_content filter, we can fix that (at least for post/page contents).

cc @codyarsenault