### PR TITLE
Hides admin page if must-use plugin or via global setting

### DIFF
--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -64,13 +64,20 @@ class CDN_Enabler
                 'register_settings',
             ]
         );
-        add_action(
-            'admin_menu',
-            [
-                'CDN_Enabler_Settings',
-                'add_settings_page',
-            ]
-        );
+        if( !(
+               (defined('CDN_HIDE_IN_ADMIN') && CDN_HIDE_IN_ADMIN) // disabled via global setting
+               ||
+               (strpos( __DIR__, WPMU_PLUGIN_DIR) !== false ) // disable because must-use plugin
+            )) 
+        {
+            add_action(
+                'admin_menu',
+                [
+                    'CDN_Enabler_Settings',
+                    'add_settings_page',
+                ]
+            );
+        }
         add_filter(
             'plugin_action_links_' .CDN_ENABLER_BASE,
             [


### PR DESCRIPTION
Detects if the current plugin is in the must-use plugin path, or if a constant CDN_HIDE_IN_ADMIN constant is true, and if so disables the admin page.

Useful for customer sites where they should not be able to see or edit infrastructure plugins.