### PR TITLE
Start output buffering earlier in execution for LSCache support

### DIFF
--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -32,7 +32,7 @@ class CDN_Enabler
     public function __construct() {
         /* CDN rewriter hook */
         add_action(
-            'template_redirect',
+            'setup_theme',
             [
                 __CLASS__,
                 'handle_rewrite_hook',


### PR DESCRIPTION
Some advanced caching plugins also use output buffering to do things like combine CSS / JS files. 

When used in conjunction with CDN-Enabler, output buffering for combine css / js fails as it fires after CDN Enabler which changes the urls to remote urls which combine css / js does not support. This results in CSS / JS served over the CDN but not in the desired combined / minified format. Changing this hook to run earlier should ensure that CDN Enabler does not conflict with LSCache or other optimization plugins.