### PR TITLE
update rewriter regex

### DIFF
--- a/inc/cdn_enabler_engine.class.php
+++ b/inc/cdn_enabler_engine.class.php
@@ -201,7 +201,7 @@ final class CDN_Enabler_Engine {
      * rewrite file contents
      *
      * @since   0.0.1
-     * @change  2.0.0
+     * @change  2.0.1
      *
      * @param   string  $contents                      contents of file
      * @return  string  $contents|$rewritten_contents  rewritten file contents if applicable, unchanged otherwise
@@ -216,7 +216,7 @@ final class CDN_Enabler_Engine {
 
         $included_file_extensions_regex = quotemeta( implode( '|', explode( PHP_EOL, self::$settings['included_file_extensions'] ) ) );
 
-        $urls_regex = '#[^\"\'\s=>(,]+(' . $included_file_extensions_regex . ')(?=\/?[?\\\"\'\s)>])#i';
+        $urls_regex = '#(?:(?:[\"\'\s=>,]|url\()\K|^)[^\"\'\s(=>,]+(' . $included_file_extensions_regex . ')(\?[^?\\\"\'\s)>,]+)?(?:(?=\/?[?\\\"\'\s)>,])|$)#i';
 
         $rewritten_contents = preg_replace_callback( $urls_regex, 'self::rewrite_url', $contents );
 


### PR DESCRIPTION
Update regular expression used to match URLs in the `CDN_Enabler_Engine::rewriter()` method. This fixes unwanted matches, like where `document.head.innerHTML.match(/\.pagespeed\..+?\.js/)` was being matched while using the Divi page builder. This will now include query strings in the matched URL. This will now allow individual URLs to be sent through the rewriter.

Regex tests:

* Old pattern: https://regex101.com/r/v3g3G4/1

* New pattern: https://regex101.com/r/IZiFnF/1