### PR TITLE
update settings conversion

### DIFF
--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -342,7 +342,7 @@ final class CDN_Enabler {
      * convert settings to new structure
      *
      * @since   2.0.0
-     * @change  2.0.0
+     * @change  2.0.1
      *
      * @param   array  $settings  settings
      * @return  array  $settings  converted settings if applicable, unchanged otherwise
@@ -353,6 +353,11 @@ final class CDN_Enabler {
         // check if there are any settings to convert
         if ( empty( $settings ) ) {
             return $settings;
+        }
+
+        // updated settings
+        if ( isset( $settings['url'] ) && is_string( $settings['url'] ) && substr_count( $settings['url'], '/' ) > 2 ) {
+            $settings['url'] = '';
         }
 
         // reformatted settings


### PR DESCRIPTION
Update the `CDN_Enabler::convert_settings()` method to convert the CDN URL to an empty string if there are more than two `/`. This will prevent sites that had a file path in the old CDN URL setting from being converted to the new CDN Hostname setting value.