### PR TITLE
update hooks and fix configuration validation

### DIFF
--- a/cdn-enabler.php
+++ b/cdn-enabler.php
@@ -37,7 +37,7 @@ define( 'CDN_ENABLER_MIN_PHP', '5.6' );
 define( 'CDN_ENABLER_MIN_WP', '5.1' );
 define( 'CDN_ENABLER_FILE', __FILE__ );
 define( 'CDN_ENABLER_BASE', plugin_basename( __FILE__ ) );
-define( 'CDN_ENABLER_DIR', dirname( __FILE__ ) );
+define( 'CDN_ENABLER_DIR', __DIR__ );
 
 // hooks
 add_action( 'plugins_loaded', array( 'CDN_Enabler', 'init' ) );
@@ -57,7 +57,6 @@ function cdn_enabler_autoload( $class_name ) {
         );
     }
 }
-
 
 // load WP-CLI command
 if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {

--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -873,7 +873,7 @@ final class CDN_Enabler {
      * validate configuration
      *
      * @since   2.0.0
-     * @change  2.0.0
+     * @change  2.0.1
      *
      * @param   array  $validated_settings  validated settings
      * @return  array  $validated_settings  validated settings
@@ -885,12 +885,14 @@ final class CDN_Enabler {
             return $validated_settings;
         }
 
-        // get validation test file
-        $test_file = parse_url( home_url(), PHP_URL_SCHEME ) . '://' . $validated_settings['cdn_hostname'] . '/' . str_replace( ABSPATH, '', CDN_ENABLER_DIR ) . '/css/settings.min.css';
+        // get validation request URL
+        CDN_Enabler_Engine::$settings['cdn_hostname'] = $validated_settings['cdn_hostname'];
+        CDN_Enabler_Engine::$settings['included_file_extensions'] = '.css';
+        $validation_request_url = CDN_Enabler_Engine::rewriter( plugins_url( 'css/settings.min.css', CDN_ENABLER_FILE ) );
 
         // validation request
         $response = wp_remote_get(
-            $test_file,
+            $validation_request_url,
             array(
                 'method'      => 'HEAD',
                 'timeout'     => 15,

--- a/readme.txt
+++ b/readme.txt
@@ -47,6 +47,13 @@ CDN Enabler captures page contents and rewrites URLs to be served by the designa
 
 == Changelog ==
 
+= 2.0.1 =
+* Update URL matcher in rewriter (#25)
+* Update settings conversion (#26)
+* Add `cdn_enabler_exclude_admin`, `cdn_enabler_contents_before_rewrite`, and `cdn_enabler_contents_after_rewrite` filter hooks (#27)
+* Fix configuration validation for installations in a subdirectory (#27)
+* Remove `cdn_enabler_page_contents_before_rewrite` filter hook in favor of replacement (#27)
+
 = 2.0.0 =
 * Update output buffer timing to start earlier on the `setup_theme` hook instead of the `template_redirect` hook (#23)
 * Update settings (#23)


### PR DESCRIPTION
Add three filter hooks:

* `cdn_enabler_exclude_admin` filter hook to indicate whether the admin pages should bypass the rewrite. By default admin pages do bypass the rewrite.

* `cdn_enabler_contents_before_rewrite` filter hook to filter contents before going through the rewriter.

* `cdn_enabler_contents_after_rewrite` filter hook to filter contents after going through the rewriter.

Remove `cdn_enabler_page_contents_before_rewrite` in favor of `cdn_enabler_contents_before_rewrite`. This makes it so any content going through the rewriter, not just from the output buffer, can be filtered. The contents sent from the output buffer can be more than just page contents, such as JSON from an API call.

Fix configuration validation for installations in a subdirectory by ensuring the validation request URL contains the subdirectory.