### PR TITLE
update full URL rewrite and rewriter regex

### DIFF
--- a/inc/cdn_enabler_engine.class.php
+++ b/inc/cdn_enabler_engine.class.php
@@ -172,7 +172,7 @@ final class CDN_Enabler_Engine {
      * rewrite URL to use CDN hostname
      *
      * @since   0.0.1
-     * @change  2.0.0
+     * @change  2.0.1
      *
      * @param   array   $matches   pattern matches from parsed contents
      * @return  string  $file_url  rewritten file URL if applicable, unchanged otherwise
@@ -192,8 +192,8 @@ final class CDN_Enabler_Engine {
 
         // rewrite full URL (e.g. https://www.example.com/wp..., https:\/\/www.example.com\/wp..., or //www.example.com/wp...)
         foreach ( $site_hostnames as $site_hostname ) {
-            if ( stripos( $file_url, '/' . $site_hostname ) !== false ) {
-                return str_replace( $site_hostname, $cdn_hostname, $file_url );
+            if ( stripos( $file_url, '//' . $site_hostname ) !== false || stripos( $file_url, '\/\/' . $site_hostname ) !== false ) {
+                return substr_replace( $file_url, $cdn_hostname, stripos( $file_url, $site_hostname ), strlen( $site_hostname ) );
             }
         }
 
@@ -235,7 +235,7 @@ final class CDN_Enabler_Engine {
 
         $included_file_extensions_regex = quotemeta( implode( '|', explode( PHP_EOL, self::$settings['included_file_extensions'] ) ) );
 
-        $urls_regex = '#(?:(?:[\"\'\s=>,]|url\()\K|^)[^\"\'\s(=>,]+(' . $included_file_extensions_regex . ')(\?[^?\\\"\'\s)>,]+)?(?:(?=\/?[?\\\"\'\s)>,])|$)#i';
+        $urls_regex = '#(?:(?:[\"\'\s=>,]|url\()\K|^)[^\"\'\s(=>,]+(' . $included_file_extensions_regex . ')(\?[^\/?\\\"\'\s)>,]+)?(?:(?=\/?[?\\\"\'\s)>,])|$)#i';
 
         $rewritten_contents = apply_filters( 'cdn_enabler_contents_after_rewrite', preg_replace_callback( $urls_regex, 'self::rewrite_url', $contents ) );
 

--- a/inc/cdn_enabler_engine.class.php
+++ b/inc/cdn_enabler_engine.class.php
@@ -172,7 +172,7 @@ final class CDN_Enabler_Engine {
      * rewrite URL to use CDN hostname
      *
      * @since   0.0.1
-     * @change  2.0.1
+     * @change  2.0.2
      *
      * @param   array   $matches   pattern matches from parsed contents
      * @return  string  $file_url  rewritten file URL if applicable, unchanged otherwise

--- a/readme.txt
+++ b/readme.txt
@@ -48,8 +48,9 @@ CDN Enabler captures page contents and rewrites URLs to be served by the designa
 == Changelog ==
 
 = 2.0.1 =
-* Update URL matcher in rewriter (#25)
+* Update URL matcher in rewriter (#25 and #28)
 * Update settings conversion (#26)
+* Update full URL rewrite (#28)
 * Add `cdn_enabler_exclude_admin`, `cdn_enabler_contents_before_rewrite`, and `cdn_enabler_contents_after_rewrite` filter hooks (#27)
 * Fix configuration validation for installations in a subdirectory (#27)
 * Remove `cdn_enabler_page_contents_before_rewrite` filter hook in favor of replacement (#27)

--- a/readme.txt
+++ b/readme.txt
@@ -47,10 +47,13 @@ CDN Enabler captures page contents and rewrites URLs to be served by the designa
 
 == Changelog ==
 
-= 2.0.1 =
-* Update URL matcher in rewriter (#25 and #28)
-* Update settings conversion (#26)
+= 2.0.2 =
+* Update URL matcher in rewriter (#28)
 * Update full URL rewrite (#28)
+
+= 2.0.1 =
+* Update URL matcher in rewriter (#25)
+* Update settings conversion (#26)
 * Add `cdn_enabler_exclude_admin`, `cdn_enabler_contents_before_rewrite`, and `cdn_enabler_contents_after_rewrite` filter hooks (#27)
 * Fix configuration validation for installations in a subdirectory (#27)
 * Remove `cdn_enabler_page_contents_before_rewrite` filter hook in favor of replacement (#27)


### PR DESCRIPTION
Update `CDN_Enabler_Engine::rewrite_url()` to only replace the first occurrence of the site hostname when rewriting a full URL. Previously all occurrences would be rewritten, which means `https://www.example.com/wp-content/www.example.com/uploads/example.jpg` would become `https://cdn.example.com/wp-content/cdn.example.com/uploads/example.jpg`. `substr_replace()` was chosen over `preg_replace()` with a limit because it performs better. This will also prevent a third party URL that contains the site hostname from being rewritten (e.g. `https://foobar.com/www.example.com/tracking.js` to `https://foobar.com/cdn.example.com/tracking.js`).

Update regular expression used to match URLs in the `CDN_Enabler_Engine::rewriter()` method. This updates PR #25 by only adding `/` as character that should not match when in a query string.

Regex tests:

* Old pattern: https://regex101.com/r/GOPPBN/1

* New pattern: https://regex101.com/r/SKHHsA/1