### PR TITLE
fix purge cache request handling

### DIFF
--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -554,7 +554,7 @@ final class CDN_Enabler {
      * process purge cache request
      *
      * @since   1.0.5
-     * @change  2.0.0
+     * @change  2.0.3
      */
 
     public static function process_purge_cache_request() {
@@ -578,7 +578,7 @@ final class CDN_Enabler {
         $response = self::purge_cdn_cache();
 
         // redirect to same page
-        wp_safe_redirect( wp_get_referer() );
+        wp_safe_redirect( remove_query_arg( array( '_cache', '_action', '_wpnonce' ) ) );
 
         // set transient for purge notice
         if ( is_admin() ) {


### PR DESCRIPTION
Fix purge cache request handling to redirect to the current URL path with the query parameters `_cache`, `_action`, `_wpnonce` removed instead of [`wp_get_referer()`](https://developer.wordpress.org/reference/functions/wp_get_referer/). Previously, if the `Referer` request header was not sent, like if `Referrer-Policy: no-referrer` response header was set, this would cause the redirect to be cancelled and then the script to be terminated. This lead to the response body being empty.