### PR TITLE
update getting blog IDs

### DIFF
--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -239,18 +239,19 @@ final class CDN_Enabler {
      * get blog IDs
      *
      * @since   2.0.0
-     * @change  2.0.0
+     * @change  2.0.4
      *
      * @return  array  $blog_ids  blog IDs
      */
 
     private static function get_blog_ids() {
 
-        $blog_ids = array( '1' );
+        $blog_ids = array( 1 );
 
         if ( is_multisite() ) {
             global $wpdb;
-            $blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+
+            $blog_ids = array_map( 'absint', $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" ) );
         }
 
         return $blog_ids;


### PR DESCRIPTION
Update `CDN_Enabler::get_blog_ids()` to return integers (comes from the same change made in keycdn/cache-enabler#215).