### PR TITLE
update CDN hostname validation

### DIFF
--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -802,7 +802,7 @@ final class CDN_Enabler {
      * validate CDN hostname
      *
      * @since   2.0.0
-     * @change  2.0.0
+     * @change  2.0.4
      *
      * @param   string  $cdn_hostname            CDN hostname
      * @return  string  $validated_cdn_hostname  validated CDN hostname
@@ -810,7 +810,7 @@ final class CDN_Enabler {
 
     private static function validate_cdn_hostname( $cdn_hostname ) {
 
-        $cdn_url = esc_url_raw( $cdn_hostname, array( 'http', 'https' ) );
+        $cdn_url = esc_url_raw( trim( $cdn_hostname ), array( 'http', 'https' ) );
         $validated_cdn_hostname = strtolower( (string) parse_url( $cdn_url, PHP_URL_HOST ) );
 
         return $validated_cdn_hostname;


### PR DESCRIPTION
Update CDN hostname validation to trim whitespace characters before being cleaned with [`esc_url_raw()`](https://developer.wordpress.org/reference/functions/esc_url_raw/). This will prevent an unnecessary validation failure, such as "cURL error 6: Could not resolve host: cdn.example.com%20".