### PR TITLE
update rewriter regex

### DIFF
--- a/inc/cdn_enabler_engine.class.php
+++ b/inc/cdn_enabler_engine.class.php
@@ -218,7 +218,7 @@ final class CDN_Enabler_Engine {
      * rewrite contents
      *
      * @since   0.0.1
-     * @change  2.0.1
+     * @change  2.0.4
      *
      * @param   string  $contents                      contents to parse
      * @return  string  $contents|$rewritten_contents  rewritten contents if applicable, unchanged otherwise
@@ -235,7 +235,7 @@ final class CDN_Enabler_Engine {
 
         $included_file_extensions_regex = quotemeta( implode( '|', explode( PHP_EOL, self::$settings['included_file_extensions'] ) ) );
 
-        $urls_regex = '#(?:(?:[\"\'\s=>,]|url\()\K|^)[^\"\'\s(=>,]+(' . $included_file_extensions_regex . ')(\?[^\/?\\\"\'\s)>,]+)?(?:(?=\/?[?\\\"\'\s)>,])|$)#i';
+        $urls_regex = '#(?:(?:[\"\'\s=>,;]|url\()\K|^)[^\"\'\s(=>,;]+(' . $included_file_extensions_regex . ')(\?[^\/?\\\"\'\s)>,]+)?(?:(?=\/?[?\\\"\'\s)>,&])|$)#i';
 
         $rewritten_contents = apply_filters( 'cdn_enabler_contents_after_rewrite', preg_replace_callback( $urls_regex, 'self::rewrite_url', $contents ) );
 


### PR DESCRIPTION
Update regular expression used to match URLs in the `CDN_Enabler_Engine::rewriter()` method. This updates the rewriter to also rewrite inline URLs that are in escaped JSON format, for example:

```
&quot;url&quot;:&quot;\/wp-content\/uploads\/example.jpg&quot;
```

Regex tests:

* Old pattern: https://regex101.com/r/IZiFnF/1

* New pattern: https://regex101.com/r/v0yB7U/1/