### PR TITLE
update configuration validation

### DIFF
--- a/inc/cdn_enabler.class.php
+++ b/inc/cdn_enabler.class.php
@@ -876,7 +876,7 @@ final class CDN_Enabler {
      * validate configuration
      *
      * @since   2.0.0
-     * @change  2.0.1
+     * @change  2.0.4
      *
      * @param   array  $validated_settings  validated settings
      * @return  array  $validated_settings  validated settings
@@ -900,6 +900,7 @@ final class CDN_Enabler {
                 'method'      => 'HEAD',
                 'timeout'     => 15,
                 'httpversion' => '1.1',
+                'headers'     => array( 'Referer' => home_url() ),
             )
         );
 


### PR DESCRIPTION
Update configuration validation to include the [`home_url()`](https://developer.wordpress.org/reference/functions/home_url/) as an HTTP `Referer` in the test request.  This URL is what the frontend uses and will be the base HTTP `Referer` for the majority of requests to the CDN. While some HTTP referrers may have the CDN hostname in them and not just the site hostname, I do not think it is worth making a second request to also check this. Furthermore, having the CDN hostname as an allowed HTTP referrer is not required if a website does not have assets delivered by the CDN that are then making requests to other assets delivered by the CDN. Updating this validation will prevent rewriting URLs to use the CDN hostname if a `403` status would be returned when being requested by the pages that have been rewritten.